### PR TITLE
Fixes #14. Track registered items using a `WeakSet`

### DIFF
--- a/src/DraggableGrid.tsx
+++ b/src/DraggableGrid.tsx
@@ -157,11 +157,7 @@ function DraggableGrid(
       {data.map((item) => {
         const id = get(item, uniKey)
         return (
-          <div
-            className="ruuri-draggable-item ruuri-draggable-item-initial draggable-item"
-            data-ruuri-id={id}
-            key={id}
-          >
+          <div className="ruuri-draggable-item draggable-item" data-ruuri-id={id} key={id}>
             <div className="draggable-item-content">{renderItem?.(item)}</div>
           </div>
         )


### PR DESCRIPTION
Tracking newly added items to the grid by adding/removing classes (or other HTML attributes) seems unreliable due to React's nature.
In this PR, tracking registered items is implemented using `WeakSet`.

Fixes #14 